### PR TITLE
Add php-cs-fixer for php check

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,14 @@
+name: php-cs-fixer
+on: [pull_request]
+
+jobs:
+    php-cs-fixer:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: Prepare
+              run: |
+                  wget https://cs.symfony.com/download/php-cs-fixer-v2.phar -O php-cs-fixer
+                  chmod a+x php-cs-fixer
+            - name: php-cs-fixer
+              run: php php-cs-fixer fix ./src --dry-run


### PR DESCRIPTION
# 概要

現在は、php-cs-fixerのチェックも何も実行されていないため、導入する。
個人の開発において、自分以外のチェックを入れる方が、効率と保守性が上がるため。